### PR TITLE
bugfix: fix core test failure

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -148,7 +148,12 @@ if ($hassiteconfig) {
     }
 
     $settings->add(new admin_setting_configmulticheckbox('logstore_xapi/routes',
-        get_string('routes', 'logstore_xapi'), '', $menuroutes, $menuroutes));
+        get_string('routes', 'logstore_xapi'),
+        '',
+        // Empty array as default breaks core unit tests, so use null if there are no defaults.
+        empty($menuroutes) ? null : $menuroutes,
+        $menuroutes
+    ));
 
     // The xAPI Error Log page.
     $errorreport = new admin_externalpage(


### PR DESCRIPTION
Fixes a core test `adminlib_test.php`, which is testing the saving/loading of the admin tree and the defaults.

There seems to be a tiny difference internally in the adminlib between an empty array and null. This shouldn't affect anything as this `$menuroutes` array is empty anyway (at least on my machine)