### PR TITLE
[#876] Fix logstore_xapi tests breaking mod_lesson tests

### DIFF
--- a/tests/core/badge_awarded/user_achieved_badge/user_achieved_badge_test.php
+++ b/tests/core/badge_awarded/user_achieved_badge/user_achieved_badge_test.php
@@ -64,7 +64,7 @@ final class user_achieved_badge_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/badge_revoked/user_forfeited_badge/user_forfeited_badge_test.php
+++ b/tests/core/badge_revoked/user_forfeited_badge/user_forfeited_badge_test.php
@@ -63,7 +63,7 @@ final class user_forfeited_badge_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/badge_updated/badge_updated_test.php
+++ b/tests/core/badge_updated/badge_updated_test.php
@@ -64,7 +64,7 @@ final class badge_updated_test extends \logstore_xapi\xapi_test_case {
      * @covers ::badge_updated
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/badge_viewed/user_viewed_badge/user_viewed_badge_test.php
+++ b/tests/core/badge_viewed/user_viewed_badge/user_viewed_badge_test.php
@@ -64,7 +64,7 @@ final class user_viewed_badge_test extends \logstore_xapi\xapi_test_case {
      * @covers ::badge_viewed
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/calendar_event_created/user_created_calendar_event/user_created_calendar_event_test.php
+++ b/tests/core/calendar_event_created/user_created_calendar_event/user_created_calendar_event_test.php
@@ -20,6 +20,8 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 
+require_once($CFG->dirroot . '/admin/tool/log/store/xapi/tests/xapi_test_case.php');
+
 /**
  * Unit test for calendar_event_created event.
  *
@@ -62,7 +64,7 @@ final class user_created_calendar_event_test extends \logstore_xapi\xapi_test_ca
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/calendar_event_deleted/user_deleted_calendar_event/user_deleted_calendar_event_test.php
+++ b/tests/core/calendar_event_deleted/user_deleted_calendar_event/user_deleted_calendar_event_test.php
@@ -64,7 +64,7 @@ final class user_deleted_calendar_event_test extends \logstore_xapi\xapi_test_ca
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/calendar_event_updated/user_updated_calendar_event/user_updated_calendar_event_test.php
+++ b/tests/core/calendar_event_updated/user_updated_calendar_event/user_updated_calendar_event_test.php
@@ -20,6 +20,8 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 
+require_once($CFG->dirroot . '/admin/tool/log/store/xapi/tests/xapi_test_case.php');
+
 /**
  * Unit test calendar_event_updated event.
  *
@@ -62,6 +64,6 @@ final class user_updated_calendar_event_test extends \logstore_xapi\xapi_test_ca
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
     }
 }

--- a/tests/core/calendar_subscription_created/user_created_calendar_subscription/user_created_calendar_subscription_test.php
+++ b/tests/core/calendar_subscription_created/user_created_calendar_subscription/user_created_calendar_subscription_test.php
@@ -65,7 +65,7 @@ final class user_created_calendar_subscription_test extends \logstore_xapi\xapi_
      * @covers ::calendar_subscription_created
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/calendar_subscription_deleted/user_deleted_calendar_subscription/user_deleted_calendar_subscription_test.php
+++ b/tests/core/calendar_subscription_deleted/user_deleted_calendar_subscription/user_deleted_calendar_subscription_test.php
@@ -64,7 +64,7 @@ final class user_deleted_calendar_subscription_test extends \logstore_xapi\xapi_
      * @covers ::calendar_subscription_deleted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/calendar_subscription_updated/user_updated_calendar_subscription/user_updated_calendar_subscription_test.php
+++ b/tests/core/calendar_subscription_updated/user_updated_calendar_subscription/user_updated_calendar_subscription_test.php
@@ -64,7 +64,7 @@ final class user_updated_calendar_subscription_test extends \logstore_xapi\xapi_
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/course_category_created/course_category_created_test.php
+++ b/tests/core/course_category_created/course_category_created_test.php
@@ -64,7 +64,7 @@ final class course_category_created_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/course_completed/completing_existing_course/completing_existing_course_test.php
+++ b/tests/core/course_completed/completing_existing_course/completing_existing_course_test.php
@@ -66,7 +66,7 @@ final class completing_existing_course_test extends \logstore_xapi\xapi_test_cas
      * @covers ::course_completed
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/course_completed/send_jisc_data/send_jisc_data_test.php
+++ b/tests/core/course_completed/send_jisc_data/send_jisc_data_test.php
@@ -79,7 +79,7 @@ final class send_jisc_data_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_completed
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/course_completion_updated/course_completion_updated/course_completion_updated_test.php
+++ b/tests/core/course_completion_updated/course_completion_updated/course_completion_updated_test.php
@@ -64,7 +64,7 @@ final class course_completion_updated_test extends \logstore_xapi\xapi_test_case
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/course_created/creating_new_course/creating_new_course_test.php
+++ b/tests/core/course_created/creating_new_course/creating_new_course_test.php
@@ -64,7 +64,7 @@ final class creating_new_course_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/course_module_completion_update/completing_existing_module/completing_existing_module_test.php
+++ b/tests/core/course_module_completion_update/completing_existing_module/completing_existing_module_test.php
@@ -67,7 +67,7 @@ final class completing_existing_module_test extends \logstore_xapi\xapi_test_cas
      * @covers ::course_module_completion_updated
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/course_module_completion_update/uncompleting_existing_module/uncompleting_existing_module_test.php
+++ b/tests/core/course_module_completion_update/uncompleting_existing_module/uncompleting_existing_module_test.php
@@ -64,7 +64,7 @@ final class uncompleting_existing_module_test extends \logstore_xapi\xapi_test_c
      * @covers ::course_module_completion_updated
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/course_module_created/creating_new_course_module/creating_new_course_module_test.php
+++ b/tests/core/course_module_created/creating_new_course_module/creating_new_course_module_test.php
@@ -64,7 +64,7 @@ final class creating_new_course_module_test extends \logstore_xapi\xapi_test_cas
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/course_resources_list_viewed/existing_course_resources_list_viewed/existing_course_resources_list_viewed_test.php
+++ b/tests/core/course_resources_list_viewed/existing_course_resources_list_viewed/existing_course_resources_list_viewed_test.php
@@ -64,7 +64,7 @@ final class existing_course_resources_list_viewed_test extends \logstore_xapi\xa
      * @covers ::course_viewed
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/course_section_created/new_course_section_created/new_course_section_created.php
+++ b/tests/core/course_section_created/new_course_section_created/new_course_section_created.php
@@ -63,7 +63,7 @@ class new_course_section_created_test extends \logstore_xapi\xapi_test_case {
      *
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/course_updated/updating_existing_course/updating_existing_course_test.php
+++ b/tests/core/course_updated/updating_existing_course/updating_existing_course_test.php
@@ -64,7 +64,7 @@ final class updating_existing_course_test extends \logstore_xapi\xapi_test_case 
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/course_viewed/viewing_existing_course/viewing_existing_course_test.php
+++ b/tests/core/course_viewed/viewing_existing_course/viewing_existing_course_test.php
@@ -66,7 +66,7 @@ final class viewing_existing_course_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_viewed
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/group_created/creating_new_group/creating_new_group_test.php
+++ b/tests/core/group_created/creating_new_group/creating_new_group_test.php
@@ -63,7 +63,7 @@ final class creating_new_group_test extends \logstore_xapi\xapi_test_case {
      *
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/group_deleted/existing_group_deleted_test/existing_group_deleted_test.php
+++ b/tests/core/group_deleted/existing_group_deleted_test/existing_group_deleted_test.php
@@ -63,7 +63,7 @@ final class existing_group_deleted_test extends \logstore_xapi\xapi_test_case {
      *
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/group_member_added/new_group_member_added_test/new_group_member_added_test.php
+++ b/tests/core/group_member_added/new_group_member_added_test/new_group_member_added_test.php
@@ -63,7 +63,7 @@ final class new_group_member_added_test extends \logstore_xapi\xapi_test_case {
      *
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/group_member_removed/existing_group_member_removed_test/existing_group_member_removed_test.php
+++ b/tests/core/group_member_removed/existing_group_member_removed_test/existing_group_member_removed_test.php
@@ -63,7 +63,7 @@ final class existing_group_member_removed_test extends \logstore_xapi\xapi_test_
      *
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/group_message_sent/new_group_message_sent/new_group_message_sent_test.php
+++ b/tests/core/group_message_sent/new_group_message_sent/new_group_message_sent_test.php
@@ -64,7 +64,7 @@ final class new_group_message_sent_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/message_sent/user_sent_message/user_sent_message_test.php
+++ b/tests/core/message_sent/user_sent_message/user_sent_message_test.php
@@ -64,7 +64,7 @@ final class user_sent_message_test extends \logstore_xapi\xapi_test_case {
      * @covers ::message_sent
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/message_viewed/user_viewed_message/user_viewed_message_test.php
+++ b/tests/core/message_viewed/user_viewed_message/user_viewed_message_test.php
@@ -64,7 +64,7 @@ final class user_viewed_message_test extends \logstore_xapi\xapi_test_case {
      * @covers ::message_viewed
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/note_created/user_created_note/user_created_note_test.php
+++ b/tests/core/note_created/user_created_note/user_created_note_test.php
@@ -64,7 +64,7 @@ final class user_created_note_test extends \logstore_xapi\xapi_test_case {
      * @covers ::note_created
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/note_updated/user_updated_note/user_updated_note_test.php
+++ b/tests/core/note_updated/user_updated_note/user_updated_note_test.php
@@ -64,7 +64,7 @@ final class user_updated_note_test extends \logstore_xapi\xapi_test_case {
      * @covers ::note_updated
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/notes_viewed/user_viewed_notes/user_viewed_notes_test.php
+++ b/tests/core/notes_viewed/user_viewed_notes/user_viewed_notes_test.php
@@ -64,7 +64,7 @@ final class user_viewed_notes_test extends \logstore_xapi\xapi_test_case {
      * @covers ::notes_viewed
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/question_created/new_question_created_test/new_question_created_test.php
+++ b/tests/core/question_created/new_question_created_test/new_question_created_test.php
@@ -63,7 +63,7 @@ final class new_question_created_test extends \logstore_xapi\xapi_test_case {
      *
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/questions_imported/new_questions_imported/new_questions_imported_test.php
+++ b/tests/core/questions_imported/new_questions_imported/new_questions_imported_test.php
@@ -64,7 +64,7 @@ final class new_questions_imported_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/search_results_viewed/user_viewed_search_results/user_viewed_search_results_test.php
+++ b/tests/core/search_results_viewed/user_viewed_search_results/user_viewed_search_results_test.php
@@ -64,7 +64,7 @@ final class user_viewed_search_results_test extends \logstore_xapi\xapi_test_cas
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/user_created/existing_user_created/existing_user_created_test.php
+++ b/tests/core/user_created/existing_user_created/existing_user_created_test.php
@@ -66,7 +66,7 @@ class existing_user_created_test extends \logstore_xapi\xapi_test_case {
      * @covers ::user_created
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/user_created/send_jisc_data/send_jisc_data_test.php
+++ b/tests/core/user_created/send_jisc_data/send_jisc_data_test.php
@@ -79,7 +79,7 @@ class send_jisc_data_test extends \logstore_xapi\xapi_test_case {
      * @covers ::user_created
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/user_enrolment_created/existing_user_enrolled/existing_user_enrolled_test.php
+++ b/tests/core/user_enrolment_created/existing_user_enrolled/existing_user_enrolled_test.php
@@ -66,7 +66,7 @@ class existing_user_enrolled_test extends \logstore_xapi\xapi_test_case {
      * @covers ::user_enrolment_created
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/user_enrolment_deleted/existing_user_enrolment_deleted/existing_user_enrolment_deleted_test.php
+++ b/tests/core/user_enrolment_deleted/existing_user_enrolment_deleted/existing_user_enrolment_deleted_test.php
@@ -64,7 +64,7 @@ final class existing_user_enrolment_deleted_test extends \logstore_xapi\xapi_tes
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/user_enrolment_updated/user_resumed_course/user_resumed_course_test.php
+++ b/tests/core/user_enrolment_updated/user_resumed_course/user_resumed_course_test.php
@@ -64,7 +64,7 @@ class user_resumed_course_test extends \logstore_xapi\xapi_test_case {
      * @covers ::user_enrolment_created
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/user_enrolment_updated/user_suspended_course/user_suspended_course_test.php
+++ b/tests/core/user_enrolment_updated/user_suspended_course/user_suspended_course_test.php
@@ -64,7 +64,7 @@ class user_suspended_course_test extends \logstore_xapi\xapi_test_case {
      * @covers ::user_enrolment_created
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/user_loggedin/existing_user_loggedin/existing_user_loggedin_test.php
+++ b/tests/core/user_loggedin/existing_user_loggedin/existing_user_loggedin_test.php
@@ -66,7 +66,7 @@ class existing_user_loggedin_test extends \logstore_xapi\xapi_test_case {
      * @covers ::user_loggedin
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/user_loggedinas/existing_user_loggedinas/existing_user_loggedinas_test.php
+++ b/tests/core/user_loggedinas/existing_user_loggedinas/existing_user_loggedinas_test.php
@@ -64,7 +64,7 @@ class existing_user_loggedinas_test extends \logstore_xapi\xapi_test_case {
      * @covers ::user_loggedin
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core/user_loggedout/existing_user_loggedout/existing_user_loggedout_test.php
+++ b/tests/core/user_loggedout/existing_user_loggedout/existing_user_loggedout_test.php
@@ -66,7 +66,7 @@ class existing_user_loggedout_test extends \logstore_xapi\xapi_test_case {
      * @covers ::user_loggedout
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/core_h5p/course_module_viewed/user_viewed_h5p_test.php
+++ b/tests/core_h5p/course_module_viewed/user_viewed_h5p_test.php
@@ -64,7 +64,7 @@ class user_viewed_h5p_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_assign/assignment_graded/existing_assignment_graded_comment/existing_assignment_graded_comment_test.php
+++ b/tests/mod_assign/assignment_graded/existing_assignment_graded_comment/existing_assignment_graded_comment_test.php
@@ -66,7 +66,7 @@ class existing_assignment_graded_comment_test extends \logstore_xapi\xapi_test_c
      * @covers ::assignment_graded
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_assign/assignment_graded/existing_assignment_graded_nocomment/existing_assignment_graded_nocomment_test.php
+++ b/tests/mod_assign/assignment_graded/existing_assignment_graded_nocomment/existing_assignment_graded_nocomment_test.php
@@ -66,7 +66,7 @@ class existing_assignment_graded_nocomment_test extends \logstore_xapi\xapi_test
      * @covers ::assignment_graded
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_assign/assignment_submitted/existing_assignment_submitted/existing_assignment_submitted_test.php
+++ b/tests/mod_assign/assignment_submitted/existing_assignment_submitted/existing_assignment_submitted_test.php
@@ -66,7 +66,7 @@ class existing_assignment_submitted_test extends \logstore_xapi\xapi_test_case {
      * @covers ::assignment_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_assign/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_assign/course_module_viewed/existing_module/existing_module_test.php
@@ -64,7 +64,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_assign/feedback_viewed/user_viewed_feedback/user_viewed_feedback_test.php
+++ b/tests/mod_assign/feedback_viewed/user_viewed_feedback/user_viewed_feedback_test.php
@@ -64,7 +64,7 @@ final class user_viewed_feedback_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_assign/submission_locked/submission_locked_test.php
+++ b/tests/mod_assign/submission_locked/submission_locked_test.php
@@ -64,7 +64,7 @@ class submission_locked_test extends \logstore_xapi\xapi_test_case {
      * @covers ::submission_locked
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_assign/submission_unlocked/submission_unlocked_test.php
+++ b/tests/mod_assign/submission_unlocked/submission_unlocked_test.php
@@ -64,7 +64,7 @@ class submission_unlocked_test extends \logstore_xapi\xapi_test_case {
      * @covers ::submission_unlocked
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_assign/submission_viewed/submission_viewed_test.php
+++ b/tests/mod_assign/submission_viewed/submission_viewed_test.php
@@ -64,7 +64,7 @@ class submission_viewed_test extends \logstore_xapi\xapi_test_case {
      * @covers ::submission_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_bigbluebuttonbn/activity_management_viewed/activity_management_viewed_test.php
+++ b/tests/mod_bigbluebuttonbn/activity_management_viewed/activity_management_viewed_test.php
@@ -66,7 +66,7 @@ class activity_management_viewed_test extends \logstore_xapi\xapi_test_case {
      * @covers ::activity_management_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 

--- a/tests/mod_bigbluebuttonbn/live_session/live_session_test.php
+++ b/tests/mod_bigbluebuttonbn/live_session/live_session_test.php
@@ -66,7 +66,7 @@ class live_session_test extends \logstore_xapi\xapi_test_case {
      * @covers ::live_session
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_bigbluebuttonbn/meeting_created/meeting_created_test.php
+++ b/tests/mod_bigbluebuttonbn/meeting_created/meeting_created_test.php
@@ -66,7 +66,7 @@ class meeting_created_test extends \logstore_xapi\xapi_test_case {
      * @covers ::meeting_created
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_bigbluebuttonbn/meeting_ended/meeting_ended_test.php
+++ b/tests/mod_bigbluebuttonbn/meeting_ended/meeting_ended_test.php
@@ -66,7 +66,7 @@ class meeting_ended_test extends \logstore_xapi\xapi_test_case {
      * @covers ::meeting_ended
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_bigbluebuttonbn/meeting_joined/meeting_joined_test.php
+++ b/tests/mod_bigbluebuttonbn/meeting_joined/meeting_joined_test.php
@@ -66,7 +66,7 @@ class meeting_joined_test extends \logstore_xapi\xapi_test_case {
      * @covers ::meeting_joined
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_bigbluebuttonbn/meeting_left/meeting_left_test.php
+++ b/tests/mod_bigbluebuttonbn/meeting_left/meeting_left_test.php
@@ -66,7 +66,7 @@ class meeting_left_test extends \logstore_xapi\xapi_test_case {
      * @covers ::meeting_left
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_bigbluebuttonbn/recording_deleted/recording_deleted_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_deleted/recording_deleted_test.php
@@ -66,7 +66,7 @@ class recording_deleted_test extends \logstore_xapi\xapi_test_case {
      * @covers ::recording_deleted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_bigbluebuttonbn/recording_edited/recording_edited_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_edited/recording_edited_test.php
@@ -66,7 +66,7 @@ class recording_edited_test extends \logstore_xapi\xapi_test_case {
      * @covers ::recording_edited
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_bigbluebuttonbn/recording_imported/recording_imported_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_imported/recording_imported_test.php
@@ -66,7 +66,7 @@ class recording_imported_test extends \logstore_xapi\xapi_test_case {
      * @covers ::recording_imported
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_bigbluebuttonbn/recording_protected/recording_protected_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_protected/recording_protected_test.php
@@ -66,7 +66,7 @@ class recording_protected_test extends \logstore_xapi\xapi_test_case {
      * @covers ::recording_protected
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_bigbluebuttonbn/recording_published/recording_published_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_published/recording_published_test.php
@@ -66,7 +66,7 @@ class recording_published_test extends \logstore_xapi\xapi_test_case {
      * @covers ::recording_published
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_bigbluebuttonbn/recording_unprotected/recording_unprotected_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_unprotected/recording_unprotected_test.php
@@ -66,7 +66,7 @@ class recording_unprotected_test extends \logstore_xapi\xapi_test_case {
      * @covers ::recording_unprotected
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_bigbluebuttonbn/recording_unpublished/recording_unpublished_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_unpublished/recording_unpublished_test.php
@@ -66,7 +66,7 @@ class recording_unpublished_test extends \logstore_xapi\xapi_test_case {
      * @covers ::recording_unpublished
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_bigbluebuttonbn/recording_viewed/recording_viewed_test.php
+++ b/tests/mod_bigbluebuttonbn/recording_viewed/recording_viewed_test.php
@@ -66,7 +66,7 @@ class recording_viewed_test extends \logstore_xapi\xapi_test_case {
      * @covers ::recording_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_book/chapter_created/chapter_created_test.php
+++ b/tests/mod_book/chapter_created/chapter_created_test.php
@@ -64,7 +64,7 @@ class chapter_created_test extends \logstore_xapi\xapi_test_case {
      * @covers ::chapter_created
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_book/chapter_viewed/existing_chapter_viewed_with_parent/existing_chapter_viewed_with_parent_test.php
+++ b/tests/mod_book/chapter_viewed/existing_chapter_viewed_with_parent/existing_chapter_viewed_with_parent_test.php
@@ -66,7 +66,7 @@ class existing_chapter_viewed_with_parent_test extends \logstore_xapi\xapi_test_
      * @covers ::chapter_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_book/chapter_viewed/existing_chapter_viewed_without_parent/existing_chapter_viewed_without_parent_test.php
+++ b/tests/mod_book/chapter_viewed/existing_chapter_viewed_without_parent/existing_chapter_viewed_without_parent_test.php
@@ -66,7 +66,7 @@ class existing_chapter_viewed_without_parent_test extends \logstore_xapi\xapi_te
      * @covers ::chapter_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_book/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_book/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_chat/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_chat/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_choice/answer_created/answer_created_test.php
+++ b/tests/mod_choice/answer_created/answer_created_test.php
@@ -91,7 +91,7 @@ class answer_created_test extends \logstore_xapi\xapi_test_case {
      * @covers ::answer_created
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_choice/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_choice/course_module_viewed/existing_module/existing_module_test.php
@@ -93,7 +93,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_data/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_data/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_facetoface/cancel_booking/existing_booking_cancelled/existing_booking_canceled_test.php
+++ b/tests/mod_facetoface/cancel_booking/existing_booking_cancelled/existing_booking_canceled_test.php
@@ -66,7 +66,7 @@ class existing_booking_canceled_test extends \logstore_xapi\xapi_test_case {
      * @covers ::cancel_booking
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_facetoface/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_facetoface/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_facetoface/signup_success/existing_signup_success/existing_signup_success_test.php
+++ b/tests/mod_facetoface/signup_success/existing_signup_success/existing_signup_success_test.php
@@ -66,7 +66,7 @@ class existing_signup_success_test extends \logstore_xapi\xapi_test_case {
      * @covers ::signup_success
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_facetoface/take_attendance/existing_attendance_taken/existing_attendance_taken_test.php
+++ b/tests/mod_facetoface/take_attendance/existing_attendance_taken/existing_attendance_taken_test.php
@@ -66,7 +66,7 @@ class existing_attendance_taken_test extends \logstore_xapi\xapi_test_case {
      * @covers ::take_attendance
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_feedback/course_module_viewed/viewing_feedback/viewing_feedback_test.php
+++ b/tests/mod_feedback/course_module_viewed/viewing_feedback/viewing_feedback_test.php
@@ -66,7 +66,7 @@ class viewing_feedback_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_feedback/response_submitted/multichoice/multichoice_test.php
+++ b/tests/mod_feedback/response_submitted/multichoice/multichoice_test.php
@@ -93,7 +93,7 @@ class multichoice_test extends \logstore_xapi\xapi_test_case {
      * @covers ::response_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_feedback/response_submitted/multichoicerated/multichoicerated_test.php
+++ b/tests/mod_feedback/response_submitted/multichoicerated/multichoicerated_test.php
@@ -93,7 +93,7 @@ class multichoicerated_test extends \logstore_xapi\xapi_test_case {
      * @covers ::response_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_feedback/response_submitted/no_items/no_items_test.php
+++ b/tests/mod_feedback/response_submitted/no_items/no_items_test.php
@@ -66,7 +66,7 @@ class no_items_test extends \logstore_xapi\xapi_test_case {
      * @covers ::response_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_feedback/response_submitted/numerical/numerical_test.php
+++ b/tests/mod_feedback/response_submitted/numerical/numerical_test.php
@@ -66,7 +66,7 @@ class numerical_test extends \logstore_xapi\xapi_test_case {
      * @covers ::response_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_feedback/response_submitted/textarea/textarea_test.php
+++ b/tests/mod_feedback/response_submitted/textarea/textarea_test.php
@@ -66,7 +66,7 @@ class textarea_test extends \logstore_xapi\xapi_test_case {
      * @covers ::response_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_feedback/response_submitted/textarea_anon/textarea_test.php
+++ b/tests/mod_feedback/response_submitted/textarea_anon/textarea_test.php
@@ -66,7 +66,7 @@ class textarea_test extends \logstore_xapi\xapi_test_case {
      * @covers ::response_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_feedback/response_submitted/textfield/textfield_test.php
+++ b/tests/mod_feedback/response_submitted/textfield/textfield_test.php
@@ -66,7 +66,7 @@ class textfield_test extends \logstore_xapi\xapi_test_case {
      * @covers ::response_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_feedback/response_submitted/unknown_typ/unknown_typ_test.php
+++ b/tests/mod_feedback/response_submitted/unknown_typ/unknown_typ_test.php
@@ -66,7 +66,7 @@ class unknown_typ_test extends \logstore_xapi\xapi_test_case {
      * @covers ::response_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_folder/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_folder/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_forum/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_forum/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_forum/discussion_created/discussion_created_test.php
+++ b/tests/mod_forum/discussion_created/discussion_created_test.php
@@ -67,7 +67,7 @@ class discussion_created_test extends \logstore_xapi\xapi_test_case {
      * @covers ::discussion_created
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_forum/discussion_subscription_created/discussion_subscription_created_test.php
+++ b/tests/mod_forum/discussion_subscription_created/discussion_subscription_created_test.php
@@ -64,7 +64,7 @@ class discussion_subscription_created_test extends \logstore_xapi\xapi_test_case
      * @covers ::discussion_subscription_created_test
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_forum/discussion_subscription_deleted/discussion_subscription_deleted_test.php
+++ b/tests/mod_forum/discussion_subscription_deleted/discussion_subscription_deleted_test.php
@@ -64,7 +64,7 @@ class discussion_subscription_deleted_test extends \logstore_xapi\xapi_test_case
      * @covers ::discussion_subscription_deleted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_forum/discussion_viewed/existing_discussion_viewed/existing_discussion_viewed_test.php
+++ b/tests/mod_forum/discussion_viewed/existing_discussion_viewed/existing_discussion_viewed_test.php
@@ -66,7 +66,7 @@ class existing_discussion_viewed_test extends \logstore_xapi\xapi_test_case {
      * @covers ::existing_discussion_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_forum/post_created/post_created_test.php
+++ b/tests/mod_forum/post_created/post_created_test.php
@@ -67,7 +67,7 @@ class post_created_test extends \logstore_xapi\xapi_test_case {
      * @covers ::post_created
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_forum/post_deleted/post_deleted_test.php
+++ b/tests/mod_forum/post_deleted/post_deleted_test.php
@@ -64,7 +64,7 @@ class post_deleted_test extends \logstore_xapi\xapi_test_case {
      * @covers ::post_deleted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_forum/post_updated/post_updated_test.php
+++ b/tests/mod_forum/post_updated/post_updated_test.php
@@ -65,7 +65,7 @@ class post_updated_test extends \logstore_xapi\xapi_test_case {
      * @covers ::post_updated
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_forum/subscription_created/subscription_created_test.php
+++ b/tests/mod_forum/subscription_created/subscription_created_test.php
@@ -64,7 +64,7 @@ class subscription_created_test extends \logstore_xapi\xapi_test_case {
      * @covers ::subscription_created
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_forum/subscription_deleted/subscription_deleted_test.php
+++ b/tests/mod_forum/subscription_deleted/subscription_deleted_test.php
@@ -64,7 +64,7 @@ class subscription_deleted_test extends \logstore_xapi\xapi_test_case {
      * @covers ::subscription_deleted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_forum/user_report_viewed/existing_report_viewed/existing_report_viewed_test.php
+++ b/tests/mod_forum/user_report_viewed/existing_report_viewed/existing_report_viewed_test.php
@@ -66,7 +66,7 @@ class existing_report_viewed_test extends \logstore_xapi\xapi_test_case {
      * @covers ::user_report_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_forum/user_report_viewed/existing_report_viewed_all_courses/existing_report_viewed_all_courses_test.php
+++ b/tests/mod_forum/user_report_viewed/existing_report_viewed_all_courses/existing_report_viewed_all_courses_test.php
@@ -66,7 +66,7 @@ class existing_report_viewed_all_courses_test extends \logstore_xapi\xapi_test_c
      * @covers ::user_report_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_glossary/comment_created/comment_created_test.php
+++ b/tests/mod_glossary/comment_created/comment_created_test.php
@@ -63,7 +63,7 @@ final class comment_created_test extends \logstore_xapi\xapi_test_case {
      *
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_glossary/comment_deleted/comment_deleted_test.php
+++ b/tests/mod_glossary/comment_deleted/comment_deleted_test.php
@@ -63,7 +63,7 @@ final class comment_deleted_test extends \logstore_xapi\xapi_test_case {
      *
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_glossary/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_glossary/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_glossary/entry_viewed/entry_viewed_test.php
+++ b/tests/mod_glossary/entry_viewed/entry_viewed_test.php
@@ -64,7 +64,7 @@ class entry_viewed_test extends \logstore_xapi\xapi_test_case {
      * @covers ::entry_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_imscp/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_imscp/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_lesson/content_page_viewed/content_page_viewed_test.php
+++ b/tests/mod_lesson/content_page_viewed/content_page_viewed_test.php
@@ -64,7 +64,7 @@ class content_page_viewed_test extends \logstore_xapi\xapi_test_case {
      * @covers ::content_page_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_lesson/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_lesson/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_lesson/essay_assessed/essay_assessed_test.php
+++ b/tests/mod_lesson/essay_assessed/essay_assessed_test.php
@@ -55,7 +55,7 @@ class essay_assessed_test extends \logstore_xapi\xapi_test_case {
      * @return string
      */
     protected function get_plugin_name() {
-        return "glossary";
+        return "lesson";
     }
 
     /**
@@ -64,7 +64,7 @@ class essay_assessed_test extends \logstore_xapi\xapi_test_case {
      * @covers ::essay_assessed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
         if (!defined('LESSON_PAGE_SHORTANSWER')) {
             define('LESSON_PAGE_SHORTANSWER', 1);
             define('LESSON_PAGE_TRUEFALSE', 2);

--- a/tests/mod_lesson/lesson_ended/lesson_ended_test.php
+++ b/tests/mod_lesson/lesson_ended/lesson_ended_test.php
@@ -64,7 +64,7 @@ class lesson_ended_test extends \logstore_xapi\xapi_test_case {
      * @covers ::lesson_ended
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_lesson/lesson_restarted/lesson_restarted_test.php
+++ b/tests/mod_lesson/lesson_restarted/lesson_restarted_test.php
@@ -64,7 +64,7 @@ class lesson_restarted_test extends \logstore_xapi\xapi_test_case {
      * @covers ::lesson_restarted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_lesson/lesson_resumed/lesson_resumed_test.php
+++ b/tests/mod_lesson/lesson_resumed/lesson_resumed_test.php
@@ -64,7 +64,7 @@ class lesson_resumed_test extends \logstore_xapi\xapi_test_case {
      * @covers ::lesson_resumed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_lesson/lesson_started/lesson_started_test.php
+++ b/tests/mod_lesson/lesson_started/lesson_started_test.php
@@ -64,7 +64,7 @@ class lesson_started_test extends \logstore_xapi\xapi_test_case {
      * @covers ::lesson_started
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_lesson/question_answered/choice/choice_test.php
+++ b/tests/mod_lesson/question_answered/choice/choice_test.php
@@ -91,7 +91,7 @@ class choice_test extends \logstore_xapi\xapi_test_case {
      * @covers ::question_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
         if (!defined('LESSON_PAGE_SHORTANSWER')) {
             define('LESSON_PAGE_SHORTANSWER', 1);
             define('LESSON_PAGE_ESSAY', 10);

--- a/tests/mod_lesson/question_answered/essay/essay_test.php
+++ b/tests/mod_lesson/question_answered/essay/essay_test.php
@@ -64,7 +64,7 @@ class essay_test extends \logstore_xapi\xapi_test_case {
      * @covers ::question_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
         if (!defined('LESSON_PAGE_SHORTANSWER')) {
             define('LESSON_PAGE_SHORTANSWER', 1);
             define('LESSON_PAGE_ESSAY', 10);

--- a/tests/mod_lesson/question_answered/matching/matching_test.php
+++ b/tests/mod_lesson/question_answered/matching/matching_test.php
@@ -64,7 +64,7 @@ class matching_test extends \logstore_xapi\xapi_test_case {
      * @covers ::question_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
         if (!defined('LESSON_PAGE_SHORTANSWER')) {
             define('LESSON_PAGE_SHORTANSWER', 1);
             define('LESSON_PAGE_ESSAY', 10);

--- a/tests/mod_lesson/question_answered/numerical/numerical_test.php
+++ b/tests/mod_lesson/question_answered/numerical/numerical_test.php
@@ -64,7 +64,7 @@ class numerical_test extends \logstore_xapi\xapi_test_case {
      * @covers ::question_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
         if (!defined('LESSON_PAGE_SHORTANSWER')) {
             define('LESSON_PAGE_SHORTANSWER', 1);
             define('LESSON_PAGE_ESSAY', 10);

--- a/tests/mod_lesson/question_answered/shortanswer/shortanswer_test.php
+++ b/tests/mod_lesson/question_answered/shortanswer/shortanswer_test.php
@@ -64,7 +64,7 @@ class shortanswer_test extends \logstore_xapi\xapi_test_case {
      * @covers ::question_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
         if (!defined('LESSON_PAGE_SHORTANSWER')) {
             define('LESSON_PAGE_SHORTANSWER', 1);
             define('LESSON_PAGE_ESSAY', 10);

--- a/tests/mod_lesson/question_answered/truefalse/truefalse_test.php
+++ b/tests/mod_lesson/question_answered/truefalse/truefalse_test.php
@@ -91,7 +91,7 @@ class truefalse_test extends \logstore_xapi\xapi_test_case {
      * @covers ::question_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
         if (!defined('LESSON_PAGE_SHORTANSWER')) {
             define('LESSON_PAGE_SHORTANSWER', 1);
             define('LESSON_PAGE_ESSAY', 10);

--- a/tests/mod_lesson/question_viewed/choice/choice_test.php
+++ b/tests/mod_lesson/question_viewed/choice/choice_test.php
@@ -91,7 +91,7 @@ class choice_test extends \logstore_xapi\xapi_test_case {
      * @covers ::question_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
         if (!defined('LESSON_PAGE_SHORTANSWER')) {
             define('LESSON_PAGE_SHORTANSWER', 1);
             define('LESSON_PAGE_ESSAY', 10);

--- a/tests/mod_lesson/question_viewed/essay/essay_test.php
+++ b/tests/mod_lesson/question_viewed/essay/essay_test.php
@@ -64,7 +64,7 @@ class essay_test extends \logstore_xapi\xapi_test_case {
      * @covers ::question_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
         if (!defined('LESSON_PAGE_SHORTANSWER')) {
             define('LESSON_PAGE_SHORTANSWER', 1);
             define('LESSON_PAGE_ESSAY', 10);

--- a/tests/mod_lesson/question_viewed/matching/matching_test.php
+++ b/tests/mod_lesson/question_viewed/matching/matching_test.php
@@ -64,7 +64,7 @@ class matching_test extends \logstore_xapi\xapi_test_case {
      * @covers ::question_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
         if (!defined('LESSON_PAGE_SHORTANSWER')) {
             define('LESSON_PAGE_SHORTANSWER', 1);
             define('LESSON_PAGE_ESSAY', 10);

--- a/tests/mod_lesson/question_viewed/numerical/numerical_test.php
+++ b/tests/mod_lesson/question_viewed/numerical/numerical_test.php
@@ -64,7 +64,7 @@ class numerical_test extends \logstore_xapi\xapi_test_case {
      * @covers ::question_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
         if (!defined('LESSON_PAGE_SHORTANSWER')) {
             define('LESSON_PAGE_SHORTANSWER', 1);
             define('LESSON_PAGE_ESSAY', 10);

--- a/tests/mod_lesson/question_viewed/shortanswer/shortanswer_test.php
+++ b/tests/mod_lesson/question_viewed/shortanswer/shortanswer_test.php
@@ -64,7 +64,7 @@ class shortanswer_test extends \logstore_xapi\xapi_test_case {
      * @covers ::question_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
         if (!defined('LESSON_PAGE_SHORTANSWER')) {
             define('LESSON_PAGE_SHORTANSWER', 1);
             define('LESSON_PAGE_ESSAY', 10);

--- a/tests/mod_lesson/question_viewed/truefalse/truefalse_test.php
+++ b/tests/mod_lesson/question_viewed/truefalse/truefalse_test.php
@@ -91,12 +91,15 @@ class truefalse_test extends \logstore_xapi\xapi_test_case {
      * @covers ::question_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
         if (!defined('LESSON_PAGE_SHORTANSWER')) {
             define('LESSON_PAGE_SHORTANSWER', 1);
             define('LESSON_PAGE_MULTICHOICE', 3);
             define('LESSON_PAGE_MATCHING', 5);
             define('LESSON_PAGE_NUMERICAL', 8);
+        }
+        if (!defined('LESSON_PAGE_ESSAY')) {
+            define('LESSON_PAGE_ESSAY', 10);
         }
         if (!defined('LESSON_PAGE_TRUEFALSE')) {
             define('LESSON_PAGE_TRUEFALSE', 2);

--- a/tests/mod_lti/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_lti/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_page/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_page/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_questionnaire/all_responses_viewed/all_responses_viewed_test.php
+++ b/tests/mod_questionnaire/all_responses_viewed/all_responses_viewed_test.php
@@ -63,7 +63,7 @@ final class all_responses_viewed_test extends \logstore_xapi\xapi_test_case {
      *
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_questionnaire/attempt_resumed/attempt_resumed_test.php
+++ b/tests/mod_questionnaire/attempt_resumed/attempt_resumed_test.php
@@ -63,7 +63,7 @@ final class attempt_resumed_test extends \logstore_xapi\xapi_test_case {
      *
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_questionnaire/attempt_saved/attempt_saved_test.php
+++ b/tests/mod_questionnaire/attempt_saved/attempt_saved_test.php
@@ -63,7 +63,7 @@ final class attempt_saved_test extends \logstore_xapi\xapi_test_case {
      *
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_questionnaire/attempt_submitted/attempt_submitted_test.php
+++ b/tests/mod_questionnaire/attempt_submitted/attempt_submitted_test.php
@@ -63,7 +63,7 @@ final class attempt_submitted_test extends \logstore_xapi\xapi_test_case {
      *
      * @return void
      */
-    public function test_init(): void {
+    protected function initialise_defines(): void {
         // No coverage required for this test.
     }
 }

--- a/tests/mod_questionnaire/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_questionnaire/course_module_viewed/existing_module/existing_module_test.php
@@ -64,7 +64,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_becameoverdue/attempt_becameoverdue_test.php
+++ b/tests/mod_quiz/attempt_becameoverdue/attempt_becameoverdue_test.php
@@ -64,7 +64,7 @@ class attempt_becameoverdue_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_becameoverdue
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_reviewed/existing_attempt_reviewed/existing_attempt_reviewed_test.php
+++ b/tests/mod_quiz/attempt_reviewed/existing_attempt_reviewed/existing_attempt_reviewed_test.php
@@ -66,7 +66,7 @@ class existing_attempt_reviewed_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_reviewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_started/existing_attempt_started/existing_attempt_started_test.php
+++ b/tests/mod_quiz/attempt_started/existing_attempt_started/existing_attempt_started_test.php
@@ -66,7 +66,7 @@ class existing_attempt_started_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_started
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_submitted/essay/essay_test.php
+++ b/tests/mod_quiz/attempt_submitted/essay/essay_test.php
@@ -66,7 +66,7 @@ class essay_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_submitted/essay_null_response/essay_null_response_test.php
+++ b/tests/mod_quiz/attempt_submitted/essay_null_response/essay_null_response_test.php
@@ -66,7 +66,7 @@ class essay_null_response_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_submitted/gapselect/gapselect_test.php
+++ b/tests/mod_quiz/attempt_submitted/gapselect/gapselect_test.php
@@ -66,7 +66,7 @@ class gapselect_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_submitted/match/match_test.php
+++ b/tests/mod_quiz/attempt_submitted/match/match_test.php
@@ -66,7 +66,7 @@ class match_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_submitted/multichoice/multichoice_test.php
+++ b/tests/mod_quiz/attempt_submitted/multichoice/multichoice_test.php
@@ -66,7 +66,7 @@ class multichoice_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_submitted/multichoice_withchoices/multichoice_withchoices_test.php
+++ b/tests/mod_quiz/attempt_submitted/multichoice_withchoices/multichoice_withchoices_test.php
@@ -94,7 +94,7 @@ class multichoice_withchoices_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_submitted/multichoiceset/multichoiceset_test.php
+++ b/tests/mod_quiz/attempt_submitted/multichoiceset/multichoiceset_test.php
@@ -66,7 +66,7 @@ class multichoiceset_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_submitted/multichoiceset_withchoices/multichoiceset_withchoices_test.php
+++ b/tests/mod_quiz/attempt_submitted/multichoiceset_withchoices/multichoiceset_withchoices_test.php
@@ -94,7 +94,7 @@ class multichoiceset_withchoices_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_submitted/no_questions/no_questions_test.php
+++ b/tests/mod_quiz/attempt_submitted/no_questions/no_questions_test.php
@@ -66,7 +66,7 @@ class no_questions_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_submitted/numerical/numerical_test.php
+++ b/tests/mod_quiz/attempt_submitted/numerical/numerical_test.php
@@ -66,7 +66,7 @@ class numerical_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_submitted/randomsamatch/randomsamatch_test.php
+++ b/tests/mod_quiz/attempt_submitted/randomsamatch/randomsamatch_test.php
@@ -66,7 +66,7 @@ class randomsamatch_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_submitted/shortanswer/shortanswer_test.php
+++ b/tests/mod_quiz/attempt_submitted/shortanswer/shortanswer_test.php
@@ -66,7 +66,7 @@ class shortanswer_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_submitted/truefalse/truefalse_test.php
+++ b/tests/mod_quiz/attempt_submitted/truefalse/truefalse_test.php
@@ -66,7 +66,7 @@ class truefalse_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_submitted/unknown_qtype/unknown_qtype_test.php
+++ b/tests/mod_quiz/attempt_submitted/unknown_qtype/unknown_qtype_test.php
@@ -66,7 +66,7 @@ class unknown_qtype_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/attempt_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_quiz/attempt_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::attempt_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_quiz/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_quiz/question_manually_graded/question_manually_graded_test.php
+++ b/tests/mod_quiz/question_manually_graded/question_manually_graded_test.php
@@ -64,7 +64,7 @@ class question_manually_graded_test extends \logstore_xapi\xapi_test_case {
      * @covers ::question_manually_graded
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_resource/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_resource/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_scorm/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_scorm/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_scorm/sco_launched/existing_sco_launched/existing_sco_launched_test.php
+++ b/tests/mod_scorm/sco_launched/existing_sco_launched/existing_sco_launched_test.php
@@ -66,7 +66,7 @@ class existing_sco_launched_test extends \logstore_xapi\xapi_test_case {
      * @covers ::sco_launched
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_scorm/scoreraw_submitted/existing_scoreraw_submitted/existing_scoreraw_submitted_test.php
+++ b/tests/mod_scorm/scoreraw_submitted/existing_scoreraw_submitted/existing_scoreraw_submitted_test.php
@@ -66,7 +66,7 @@ class existing_scoreraw_submitted_test extends \logstore_xapi\xapi_test_case {
      * @covers ::scoreraw_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_scorm/status_submitted/existing_status_submitted/existing_status_submitted_test.php
+++ b/tests/mod_scorm/status_submitted/existing_status_submitted/existing_status_submitted_test.php
@@ -66,7 +66,7 @@ class existing_status_submitted_test extends \logstore_xapi\xapi_test_case {
      * @covers ::status_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_survey/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_survey/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_survey/report_viewed/report_viewed_test.php
+++ b/tests/mod_survey/report_viewed/report_viewed_test.php
@@ -64,7 +64,7 @@ class report_viewed_test extends \logstore_xapi\xapi_test_case {
      * @covers ::report_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_survey/response_submitted/response_submitted_test.php
+++ b/tests/mod_survey/response_submitted/response_submitted_test.php
@@ -64,7 +64,7 @@ class response_submitted_test extends \logstore_xapi\xapi_test_case {
      * @covers ::response_submitted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_url/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_url/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_wiki/comment_created/comment_created_test.php
+++ b/tests/mod_wiki/comment_created/comment_created_test.php
@@ -64,7 +64,7 @@ class comment_created_test extends \logstore_xapi\xapi_test_case {
      * @covers ::comment_created
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_wiki/comment_deleted/comment_deleted_test.php
+++ b/tests/mod_wiki/comment_deleted/comment_deleted_test.php
@@ -64,7 +64,7 @@ class comment_deleted_test extends \logstore_xapi\xapi_test_case {
      * @covers ::comment_deleted
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_wiki/comments_viewed/comments_viewed_test.php
+++ b/tests/mod_wiki/comments_viewed/comments_viewed_test.php
@@ -64,7 +64,7 @@ class comments_viewed_test extends \logstore_xapi\xapi_test_case {
      * @covers ::comments_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_wiki/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_wiki/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_wiki/page_viewed/page_viewed_test.php
+++ b/tests/mod_wiki/page_viewed/page_viewed_test.php
@@ -64,7 +64,7 @@ class page_viewed_test extends \logstore_xapi\xapi_test_case {
      * @covers ::page_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/mod_workshop/course_module_viewed/existing_module/existing_module_test.php
+++ b/tests/mod_workshop/course_module_viewed/existing_module/existing_module_test.php
@@ -66,7 +66,7 @@ class existing_module_test extends \logstore_xapi\xapi_test_case {
      * @covers ::course_module_viewed
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/tool_certificate/certificate_issued/certificate_issued_test.php
+++ b/tests/tool_certificate/certificate_issued/certificate_issued_test.php
@@ -64,7 +64,7 @@ class certificate_issued_test extends \logstore_xapi\xapi_test_case {
      * @covers ::certificate_issued
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/tool_certificate/certificate_revoked/certificate_revoked_test.php
+++ b/tests/tool_certificate/certificate_revoked/certificate_revoked_test.php
@@ -64,7 +64,7 @@ class certificate_revoked_test extends \logstore_xapi\xapi_test_case {
      * @covers ::certificate_revoked
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/tool_certificate/certificate_verified/certificate_verified_test.php
+++ b/tests/tool_certificate/certificate_verified/certificate_verified_test.php
@@ -64,7 +64,7 @@ class certificate_verified_test extends \logstore_xapi\xapi_test_case {
      * @covers ::certificate_verified
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/tool_usertours/tour_ended/tour_ended_test.php
+++ b/tests/tool_usertours/tour_ended/tour_ended_test.php
@@ -64,7 +64,7 @@ class tour_ended_test extends \logstore_xapi\xapi_test_case {
      * @covers ::tour_ended
      * @return void
      */
-    public function test_init() {
+    protected function initialise_defines(): void {
 
     }
 }

--- a/tests/xapi_test_case.php
+++ b/tests/xapi_test_case.php
@@ -61,6 +61,16 @@ abstract class xapi_test_case extends \advanced_testcase {
             // We use a mutable global.
             $GLOBALS['PHPUNIT_XAPI_TESTCASE'] = true;
         }
+
+        $this->initialise_defines();
+    }
+
+    /**
+     * Initialise any defines required for this test. Called by setUp().
+     * Intended to be overwritten by superclass
+     */
+    protected function initialise_defines(): void {
+        return;
     }
 
     /**
@@ -132,6 +142,7 @@ abstract class xapi_test_case extends \advanced_testcase {
     /**
      * Create the test event.
      *
+     * @runInSeparateProcess
      * @return void
      */
     public function test_create_event() {


### PR DESCRIPTION
See https://github.com/xAPI-vle/moodle-logstore_xapi/issues/876 for description of issue

Now, `vendor/bin/phpunit --testsuite=logstore_xapi_testsuite,mod_lesson_testsuite` succeeds.

Fixes various issues:
- Added run in isolated process, which uncovered various other issues:
    -  Missing `define`
    - Missing `require_once` of xapi testcase class file
    - test_init being detected as a test, meaning the `define` where dropped due to isolated process. Instead just made it a method that is called on `setUp`